### PR TITLE
Initial version of interactive metrics

### DIFF
--- a/Interactive_Metrics.ipynb
+++ b/Interactive_Metrics.ipynb
@@ -1,0 +1,424 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Towards Human-Centric Transportation and Energy Metrics: Influence of Mode, Vehicle Occupancy, Trip Distance, and Fuel Economy\n",
+    "\n",
+    "This notebook is a companion to the related paper of the same name. We publish our code for greater reproducibility and as a basis for additional innovation in this field. This notebook contains interactive graphs that can be manipulated to explore the metric space. This allows the notebook to be used by practioners as well without modifying any code."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Abstract: \n",
+    "\n",
+    "_Traditional metrics measuring transportation and energy outcomes can be augmented to better represent impacts on people's lives and systems-level performance. In this context, this study introduces two novel metrics: road capacity (as number of people traveling and accessing services) and energy intensity (as energy use for people traveling and accessing services). Current national-level distributions of available data in the United States for factors contributing to the two new integrated metrics are used as context to evaluate potential outcomes. These factors include vehicle occupancy, mode share, fuel economy, and trip distance. Variations in input values provide insights on how these factors shape efficiencies in road capacity and energy intensity. Parametric sensitivity analysis indicates that the impact of each input depends upon the metric being evaluated. For the human-centered road capacity mobility metric, increasing vehicle occupancy has the largest effect &ndash; twice that of increasing mode share for bike, walk, and transit. For the energy intensity mobility metric, the effect of improving fuel economy is the largest. However, when the focus is on accessibility (instead of mobility), for both metrics the effect of lowering average trip distance is the largest. Additionally, a novel interactive tool to visualize the results for various parameter combinations makes the metrics practitioner ready. The findings suggest that the diffusion of new human-centric metrics that benchmark outcomes associated with road capacity and energy may be significant in motivating new sustainable transportation investments and efficient utilization of infrastructure, mobility assets, and services._"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ipywidgets import interact, interactive, fixed, interact_manual\n",
+    "import ipywidgets as widgets\n",
+    "from copy import deepcopy\n",
+    "\n",
+    "import matplotlib.patches as mpatches\n",
+    "\n",
+    "from functions.vphpl_pphpl_calc import vphpl_pphpl_calc, pphpl_by_mode\n",
+    "from functions.plots_functions import violin, pdf_plot, cdf_plot, cdf_subplots, calc_ms_pvt\n",
+    "from functions.graphing_functions import cdf_plot, calculate_peit_var, get_baseline\n",
+    "\n",
+    "from ipywidgets import interactive, Layout\n",
+    "%matplotlib inline\n",
+    "import matplotlib as mpl\n",
+    "import seaborn as sns\n",
+    "\n",
+    "mpl.rcParams['figure.figsize'] = [8.0, 6.0]\n",
+    "mpl.rcParams['figure.dpi'] = 80\n",
+    "mpl.rcParams['savefig.dpi'] = 100\n",
+    "\n",
+    "mpl.rcParams['font.size'] = 13\n",
+    "mpl.rcParams['axes.labelsize'] = 13\n",
+    "mpl.rcParams['axes.titlesize'] = 13\n",
+    "mpl.rcParams['legend.fontsize'] = 'medium'\n",
+    "mpl.rcParams['figure.titlesize'] = 'medium'\n",
+    "#mpl.rcParams['figure.subplot.wspace'] = 0.25 #Use when producing 3-wide subplots\n",
+    "\n",
+    "\n",
+    "#Color-blind friendly for line plots: https://gist.github.com/thriveth/8560036\n",
+    "CB_color_cycle = ['#377eb8', '#ff7f00', '#4daf4a',\n",
+    "                  '#f781bf', '#a65628', '#984ea3',\n",
+    "                  '#999999', '#e41a1c', '#dede00']\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "results = get_baseline()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## PEIT (Personal Energy ....) Dustin, please fill in"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ms: mode share\n",
+    "# avo: average occupancy\n",
+    "# ee: energy efficiency\n",
+    "def peit1_calc(ms, avo, ee):\n",
+    "    return ms * (1/avo) * (1/ee)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def explore_peit_var(ms_range, occ_range, FE_range):\n",
+    "    cdf_plot([results['peit1']['combined'],calculate_peit_var(ms_range, occ_range, FE_range, peit1_calc)],['Baseline','Modified'],\"PEIT1 [L/km]\",['gold','red'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "interactive_plot = interactive(explore_peit_var,\n",
+    "                               ms_range=(-3.0, 3.0,0.5),\n",
+    "                               occ_range=(-3, 3, 0.5),\n",
+    "                               FE_range=(-3,3,0.5))\n",
+    "output = interactive_plot.children[-1]\n",
+    "output.layout.height = '640px'\n",
+    "interactive_plot"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "interactive_plot_1 = interactive(explore_peit_var,\n",
+    "                               ms_range=(-3.0, 3.0,0.5),\n",
+    "                               occ_range=(-3, 3, 0.5),\n",
+    "                               FE_range=(-3,3,0.5))\n",
+    "output = interactive_plot_1.children[-1]\n",
+    "output.layout.height = '640px'\n",
+    "display(interactive_plot_1)\n",
+    "interactive_plot_2 = interactive(explore_peit_var,\n",
+    "                               ms_range=(-3.0, 3.0,0.5),\n",
+    "                               occ_range=(-3, 3, 0.5),\n",
+    "                               FE_range=(-3,3,0.5))\n",
+    "output = interactive_plot_2.children[-1]\n",
+    "output.layout.height = '640px'\n",
+    "interactive_plot_2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "interactive_plot_1 = interactive(explore_peit_var,\n",
+    "                               ms_range=(-3.0, 3.0,0.5),\n",
+    "                               occ_range=(-3, 3, 0.5),\n",
+    "                               FE_range=(-3,3,0.5))\n",
+    "interactive_plot_2 = interactive(explore_peit_var,\n",
+    "                               ms_range=(-3.0, 3.0,0.5),\n",
+    "                               occ_range=(-3, 3, 0.5),\n",
+    "                               FE_range=(-3,3,0.5))\n",
+    "\n",
+    "two_graphs = widgets.HBox(children=[interactive_plot_1, interactive_plot_2], height=\"640px\", width=\"100%\")\n",
+    "for child in two_graphs.children:\n",
+    "    output = child.children[-1]\n",
+    "    output.layout.height = '640px'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "two_graphs.children"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "two_graphs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Everything below this needs to be modified by Dustin"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Standard Deviation Plots for PPHPL"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#PPHPL1 and 2 plots (combined standard deviation CDF curves)\n",
+    "cdf_plot([results['pphpl1']['combined'],calculate_pphpl_var(0,1),calculate_pphpl_var(1,0)],\n",
+    "         ['Baseline','Higher mode share\\n(transit bus, walk & bike)','Higher occupancy\\n(Private vehicle, Transit bus)'],\n",
+    "         \"People per hour per lane\",CB_color_cycle)\n",
+    "cdf_plot([results['pphpl2']['combined'],calculate_pphpl2_var(0,1,0),calculate_pphpl2_var(1,0,0),calculate_pphpl2_var(0,0,1)],\n",
+    "         ['Baseline','Higher mode share\\n(transit bus, walk & bike)','Higher occupancy\\n(Private vehicle, Transit bus)','Lower trip distance'],\n",
+    "         \"People per hour per lane (20 km)\",CB_color_cycle)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### COMBINED VPHPL and PPHPL plot"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#COMBINED VPHPL AND PPHPL PLOT\n",
+    "fig = plt.figure()\n",
+    "ax = fig.add_axes([0,0,1,1])\n",
+    "labels = []\n",
+    "def add_label(violin, label):\n",
+    "    color = violin[\"bodies\"][0].get_facecolor().flatten()\n",
+    "    labels.append((mpatches.Patch(color=color), label))\n",
+    "\n",
+    "add_label(plt.violinplot([results[\"vphpl\"][\"pvt\"],results[\"vphpl\"][\"bus\"]]), \"VPHPL\")    \n",
+    "add_label(plt.violinplot([results[\"pphpl1\"][\"pvt\"],results[\"pphpl1\"][\"bus\"],results[\"pphpl1\"][\"wb\"]]), \"PPHPL1\")\n",
+    "add_label(plt.violinplot([results[\"pphpl2\"][\"pvt\"],results[\"pphpl2\"][\"bus\"],results[\"pphpl2\"][\"wb\"]]), \"PPHPL2 (20 km)\")\n",
+    "ax.set_yscale(\"log\")\n",
+    "xticklabels = ['Private vehicle', 'Transit bus', 'Walk & bike']\n",
+    "ax.set_xticks([1,2,3])\n",
+    "ax.set_xticklabels(xticklabels)\n",
+    "plt.legend(*zip(*labels), loc=2, fontsize = 12)\n",
+    "ax.set_ylabel('Number of vehicles or people per hour per lane')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#COMBINED VPHPL AND PPHPL PLOT\n",
+    "fig = plt.figure()\n",
+    "ax = fig.add_axes([0,0,1,1])\n",
+    "labels = []\n",
+    "def add_label(violin, label):\n",
+    "    color = violin[\"bodies\"][0].get_facecolor().flatten()\n",
+    "    labels.append((mpatches.Patch(color=color), label))\n",
+    "\n",
+    "add_label(plt.violinplot([results[\"vphpl\"][\"pvt\"],results[\"vphpl\"][\"bus\"]]), \"VPHPL\")    \n",
+    "add_label(plt.violinplot([results[\"pphpl1\"][\"pvt\"],results[\"pphpl1\"][\"bus\"],results[\"pphpl1\"][\"wb\"]]), \"PPHPL\")\n",
+    "ax.set_yscale(\"log\")\n",
+    "xticklabels = ['Private vehicle', 'Transit bus', 'Walk & bike']\n",
+    "ax.set_xticks([1,2,3])\n",
+    "ax.set_xticklabels(xticklabels)\n",
+    "plt.legend(*zip(*labels), loc=2, fontsize = 12)\n",
+    "ax.set_ylabel('Number of vehicles or people per hour per lane')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Standard Deviation Plots for PEIT (interactive)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def explore_peit_var(ms_var, occ_var, FE_var):\n",
+    "    cdf_plot([results['peit1']['combined'],calculate_peit_var(ms_var, occ_var, FE_var)],['Baseline','Modified'],\"PEIT1 [L/km]\",['gold','red'])\n",
+    "    \n",
+    "interactive_plot = interactive(explore_peit_var, ms_var=(-3.0, 3.0,0.5), occ_var=(-3, 3, 0.5), FE_var=(-3,3,0.5))\n",
+    "output = interactive_plot.children[-1]\n",
+    "output.layout.height = '640px'\n",
+    "interactive_plot"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Interaction"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@interact(ms=widgets.FloatSlider(min=0,max=1.0, value=1.0), avo=widgets.IntSlider(min=1, max=5, step=1, value=1), ei=widgets.BoundedIntText(min=1, value=10))\n",
+    "def mpec_driving(ms, avo, ei):\n",
+    "    return 1.0 / (ms * (1/avo) * ei)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def print_mpec_driving(avo):\n",
+    "    print(mpec_driving(ms=1.0, avo=avo, ei=10))\n",
+    "play = widgets.Play(\n",
+    "    value=1,\n",
+    "    min=1,\n",
+    "    max=5,\n",
+    "    step=1,\n",
+    "    description=\"Press play\",\n",
+    "    disabled=False\n",
+    ")\n",
+    "slider = widgets.FloatSlider(min=1, max=5, step=0.5, description=\"avo\")\n",
+    "widgets.jslink((play, 'value'), (slider, 'value'))\n",
+    "controls = widgets.HBox([play, slider])\n",
+    "out = widgets.interactive_output(print_mpec_driving, {'avo': play})\n",
+    "display(controls, out)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Additional advanced functionality examples"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Arguments that are dependent on each other"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Arguments that are dependent on each other can be expressed manually using `observe`.  See the following example, where one variable is used to describe the bounds of another.  For more information, please see the [widget events example notebook](./Widget%20Events.ipynb)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x_widget = widgets.FloatSlider(min=0.0, max=10.0, step=0.05)\n",
+    "y_widget = widgets.FloatSlider(min=0.5, max=10.0, step=0.05, value=5.0)\n",
+    "\n",
+    "def update_x_range(*args):\n",
+    "    x_widget.max = 2.0 * y_widget.value\n",
+    "y_widget.observe(update_x_range, 'value')\n",
+    "\n",
+    "def printer(x, y):\n",
+    "    print(x, y)\n",
+    "interact(printer,x=x_widget, y=y_widget);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Flickering and jumping output\n",
+    "\n",
+    "On occasion, you may notice interact output flickering and jumping, causing the notebook scroll position to change as the output is updated. The interactive control has a layout, so we can set its height to an appropriate value (currently chosen manually) so that it will not change size as it is updated.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "from ipywidgets import interactive\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "\n",
+    "def f(m, b):\n",
+    "    plt.figure(2)\n",
+    "    x = np.linspace(-10, 10, num=1000)\n",
+    "    plt.plot(x, m * x + b)\n",
+    "    plt.ylim(-5, 5)\n",
+    "    plt.show()\n",
+    "\n",
+    "interactive_plot = interactive(f, m=(-2.0, 2.0), b=(-3, 3, 0.5))\n",
+    "output = interactive_plot.children[-1]\n",
+    "output.layout.height = '350px'\n",
+    "interactive_plot"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/functions/graphing_functions.py
+++ b/functions/graphing_functions.py
@@ -1,0 +1,123 @@
+import numpy as np
+import matplotlib.pyplot as plt
+
+from params.generate_all import generate_all
+from functions.vphpl_pphpl_calc import vphpl_pphpl_calc
+
+# Read the parameters and generate baseline values
+params = generate_all()
+results = vphpl_pphpl_calc(params)
+
+#########Std dev varying functions#########
+
+#Given binary inputs for ms, occ, fe, calculate the std dev version of PEIT1
+def calculate_peit_var(ms_var, occ_var, FE_var, calc_fn):
+    ms_bus_mod = stddev_gen(params["ms"]["bus"], ms_var)
+    ms_wb_mod = stddev_gen(params["ms"]["wb"], ms_var)
+    ms_pvt_mod = 1 - (ms_bus_mod + ms_wb_mod)
+
+    pvt_peit_std=calc_fn(ms_pvt_mod,stddev_gen(params["occ"]["pvt"], occ_var),stddev_gen(params["FE"]["pvt"], FE_var))
+    bus_peit_std=calc_fn(ms_bus_mod,stddev_gen(params["occ"]["bus"], occ_var),stddev_gen(params["FE"]["bus"], FE_var))
+    wb_peit_std=calc_fn(ms_wb_mod,1,110)
+    peit_vals_std = pvt_peit_std+bus_peit_std+wb_peit_std
+    return peit_vals_std
+
+#Given binary inputs for ms, occ, fe, pmt calculate the std dev version of PEIT2
+#Input of 1 means increase that parameter value by a standard deviation of 1
+def calculate_peit2_var(ms_var, occ_var, FE_var, pmt_var):
+    ms_bus_mod = stddev_gen(params["ms"]["bus"], ms_var)
+    ms_wb_mod = stddev_gen(params["ms"]["wb"], ms_var)
+    ms_pvt_mod = 1 - (ms_bus_mod + ms_wb_mod)
+
+    pvt_peit_std=peit1_calc(ms_pvt_mod,stddev_gen(params["occ"]["pvt"], occ_var),stddev_gen(params["FE"]["pvt"], FE_var))*stddev_gen(params["pmt"]["pvt"],pmt_var)
+    bus_peit_std=peit1_calc(ms_bus_mod,stddev_gen(params["occ"]["bus"], occ_var),stddev_gen(params["FE"]["bus"], FE_var))*stddev_gen(params["pmt"]["bus"],pmt_var)
+    wb_peit_std=peit1_calc(ms_wb_mod,1,110)*stddev_gen(params["pmt"]["wb"],pmt_var)
+    peit_vals_std = pvt_peit_std+bus_peit_std+wb_peit_std
+    return peit_vals_std
+
+#Given binary inputs for ms, occ, fe, calculate the std dev version of PPHPL
+#-1 for pmt so it is an improvement
+def calculate_pphpl_var(occ, ms):
+    ms_bus = stddev_gen(params["ms"]["bus"], ms)
+    ms_wb = stddev_gen(params["ms"]["wb"], ms)
+    ms_pvt = 1 - (ms_bus + ms_wb)
+
+    pphpl_pvt_std=pphpl_by_mode(results["vphpl"]["pvt"],params['mpw']['pvt'],stddev_gen(params["occ"]["pvt"],occ)).tolist()
+    pphpl_bus_std=pphpl_by_mode(results["vphpl"]["bus"],params['mpw']['bus'],stddev_gen(params["occ"]["bus"],occ)).tolist()
+    pphpl_wb_std=np.array([i/j * 1000 * params['mpw']['wb'] * 1  for i,j in zip(params["speed"]["wb"],results['tl']['wb'])]).flatten().tolist()
+    pphpl_combined_std = ((pphpl_pvt_std * ms_pvt) + (pphpl_bus_std*ms_bus) + (pphpl_wb_std*ms_wb)).flatten().tolist()
+     
+    return pphpl_combined_std
+
+def calculate_pphpl2_var(occ, ms, pmt):
+    road_len = 20 #km
+    ms_bus = stddev_gen(params["ms"]["bus"], ms)
+    ms_wb = stddev_gen(params["ms"]["wb"], ms)
+    ms_pvt = 1 - (ms_bus + ms_wb)
+
+    pphpl_pvt_std=pphpl_by_mode(results["vphpl"]["pvt"],params['mpw']['pvt'],stddev_gen(params["occ"]["pvt"],occ)).tolist()*stddev_gen(road_len/params['pmt']['pvt'],pmt)
+    pphpl_bus_std=pphpl_by_mode(results["vphpl"]["bus"],params['mpw']['bus'],stddev_gen(params["occ"]["bus"],occ)).tolist()*stddev_gen(road_len/params['pmt']['bus'],pmt)
+    pphpl_bus_std = [0 if i < 0 else i for i in pphpl_bus_std] #Ensure negative values are zeroed
+    pphpl_wb_std=np.array([i/j * 1000 * params['mpw']['wb'] * 1  for i,j in zip(params["speed"]["wb"],results['tl']['wb'])]).flatten().tolist()*stddev_gen(road_len/params['pmt']['wb'],pmt)
+    pphpl_combined_std = ((pphpl_pvt_std * ms_pvt) + (pphpl_bus_std*ms_bus) + (pphpl_wb_std*ms_wb)).flatten().tolist()
+    return pphpl_combined_std
+
+# Default parameter does not change anything
+# 1 adds one standard deviation
+# -1 removes one standard deviation
+def stddev_gen(vals,stddev_ratio=1):
+    stddev = np.std(vals)
+    new_vals = vals + stddev_ratio * stddev
+    new_vals=new_vals.flatten()
+    return new_vals
+
+
+def add_label(violin, label):
+    color = violin["bodies"][0].get_facecolor().flatten()
+    labels.append((mpatches.Patch(color=color), label))
+
+#CDFs of modes all in a single plot
+#Colors MUST be passed in as a list even if there's only one color
+def cdf_plot(data, labels, xaxis_title = "",colors = ['blue','orange','green']):
+    fig = plt.figure()
+    ax = fig.add_axes([0,0,1,1])
+    if (isinstance(data[0],np.ndarray) or isinstance(data[0],list)): #If we pass in a list of datasets
+        for idx in range(0,len(data)):
+            if labels[idx]=="Baseline":
+                linewidth=3
+                linestyle="--"
+            else:
+                linewidth=2
+                linestyle="-"
+            values, base = np.histogram(data[idx], bins=41)
+            base[-1]= max([max(x) for x in data])
+            cumulative = np.cumsum(values)
+            cumulative = np.append(cumulative,100)
+            
+            ######
+            median=np.percentile(data[idx], 50) #Using 47th percentile to make lines intersect with trends visually- unsure why 50th percentile doesn't lie on curve
+            plt.axhline(y=.5, xmin=0, xmax=1, color='red',linestyle=":",linewidth=1)
+            plt.axvline(x=median, ymin=0, ymax=0.5,color=colors[idx],linestyle=":",linewidth=2)
+            #plt.text(median, idx/20, round(median,3), color=colors[idx], fontsize=14)
+            print(median)
+            ######
+            
+            plt.plot(base, cumulative/100, linewidth=linewidth,linestyle=linestyle,label = labels[idx],c=colors[idx])
+            plt.fill_between(base, cumulative/100, 0, alpha=0.05,color=colors[idx])
+    else: #There is only one dataset being passed in
+        values, base = np.histogram(data, bins=41)
+        base[-1]= max(data)
+        cumulative = np.cumsum(values)
+        cumulative = np.append(cumulative,100)
+        plt.plot(base, cumulative/100, linewidth=2,label = labels,c=colors[0])
+        plt.fill_between(base, cumulative/100, 0, alpha=0.05,color=colors[0])
+    plt.text(np.percentile(data[idx], 90), 0.5, 'Median', color="red", fontsize=14)
+    ax.set_xlabel(xaxis_title)
+    plt.legend(loc="lower right")
+    plt.show()
+
+def get_baseline():
+    return results
+
+def peit1_calc(ms, avo, ee):
+    return ms * (1/avo) * (1/ee)


### PR DESCRIPTION
- Pull out all the standard deviation and cdf plotting functions to avoid
  cluttering the code
- Note that this was non-trivial because of some dependencies and assumptions
  about global variables, but I've done the best I can for now
- Pull out the initial population code since the cdf plotting depends on it,
  but add a function to return the `results` so we can use the baseline in the
  notebook
- Generate plots for PEIT in three ways:
    - single plot
    - comparitive plots (one above the other)
    - comparitive plots (side by side)
for Dustin to pick the best

Note that the comparitive plots currently flicker as you move the sliders. I
don't yet have a solution for that but will look for one when I get home.