### PR TITLE
Switch the interactive controls from fraction of std deviation to actual values

### DIFF
--- a/Interactive_Metrics.ipynb
+++ b/Interactive_Metrics.ipynb
@@ -33,7 +33,7 @@
     "\n",
     "from functions.vphpl_pphpl_calc import vphpl_pphpl_calc, pphpl_by_mode\n",
     "from functions.plots_functions import violin, pdf_plot, cdf_plot, cdf_subplots, calc_ms_pvt\n",
-    "from functions.graphing_functions import cdf_plot, calculate_peit_var, get_raw_data, summarize_params\n",
+    "from functions.graphing_functions import cdf_plot, calculate_peit_var, get_data, create_sliders, change_mean_from_kwargs\n",
     "\n",
     "from ipywidgets import interactive, Layout\n",
     "%matplotlib inline\n",
@@ -64,7 +64,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "params, results = get_raw_data()"
+    "params, results, summary = get_data()"
    ]
   },
   {
@@ -93,8 +93,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "baseline = results['peit1']['combined']\n",
-    "summary = summarize_params()"
+    "baseline = results['peit1']['combined']"
    ]
   },
   {
@@ -114,12 +113,7 @@
    "source": [
     "def get_modified_peit(**kwargs):\n",
     "    # let's say that the original mean was 10, new mean is 20. we want to add 10 to all values\n",
-    "    def change_mean(param_mode):\n",
-    "        param, mode = param_mode.split(\"_\")\n",
-    "        new_mean = kwargs[param_mode]\n",
-    "        print(\"Changing mean for %s %s to %.4f by %.4f\" % (param, mode, new_mean, new_mean - summary[param][mode][\"mean\"]))\n",
-    "        # Don't forget to flatten here; otherwise the plot will fail because we can't calculate max of an array\n",
-    "        return (params[param][mode] + (new_mean - summary[param][mode][\"mean\"])).flatten()\n",
+    "    change_mean = lambda param_mode: change_mean_from_kwargs(param_mode, kwargs)\n",
     "    \n",
     "    ms_wb_mod = change_mean(\"ms_wb\")\n",
     "    ms_transit_mod = change_mean(\"ms_bus\")\n",
@@ -149,13 +143,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def create_slider(param_mode):\n",
-    "    param, mode = param_mode.split(\"_\")\n",
-    "    return widgets.FloatSlider(**summary[param][mode])\n",
-    "    \n",
-    "def create_sliders():\n",
-    "    slider_list = [\"ms_wb\", \"ms_bus\", \"occ_bus\", \"occ_pvt\", \"FE_bus\", \"FE_pvt\"]\n",
-    "    return dict([(slider_name, create_slider(slider_name)) for slider_name in slider_list])"
+    "PEIT_SLIDER_LIST = [\"ms_wb\", \"ms_bus\", \"occ_bus\", \"occ_pvt\", \"FE_bus\", \"FE_pvt\"]"
    ]
   },
   {
@@ -173,7 +161,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# interact_manual(explore_peit_var, **create_sliders());"
+    "# interact_manual(explore_peit_var, **create_sliders(PEIT_SLIDER_LIST));"
    ]
   },
   {
@@ -182,8 +170,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "interactive_plot_1 = interactive(explore_peit_var, {'manual' : True, 'manual_name' : 'Recalculate'}, **create_sliders());\n",
-    "interactive_plot_2 = interactive(explore_peit_var, {'manual' : True, 'manual_name' : 'Recalculate'}, **create_sliders());\n",
+    "interactive_plot_1 = interactive(explore_peit_var, {'manual' : True, 'manual_name' : 'Recalculate'}, **create_sliders(PEIT_SLIDER_LIST));\n",
+    "interactive_plot_2 = interactive(explore_peit_var, {'manual' : True, 'manual_name' : 'Recalculate'}, **create_sliders(PEIT_SLIDER_LIST));\n",
     "two_graphs = widgets.HBox(children=[interactive_plot_1, interactive_plot_2])\n",
     "two_graphs"
    ]

--- a/functions/graphing_functions.py
+++ b/functions/graphing_functions.py
@@ -1,12 +1,9 @@
 import numpy as np
 import matplotlib.pyplot as plt
+import ipywidgets as widgets
 
 from params.generate_all import generate_all
 from functions.vphpl_pphpl_calc import vphpl_pphpl_calc
-
-# Read the parameters and generate baseline values
-params = generate_all()
-results = vphpl_pphpl_calc(params)
 
 #########Std dev varying functions#########
 
@@ -118,8 +115,8 @@ def cdf_plot(data, labels, xaxis_title = "",colors = ['blue','orange','green']):
     plt.legend(loc="lower right")
     plt.show()
 
-def get_raw_data():
-    return params, results
+def get_data():
+    return params, results, summary
 
 def summarize_params():
     summary = {}
@@ -134,3 +131,22 @@ def summarize_params():
             summary[param][mode]["step"] = (summary[param][mode]["max"] - summary[param][mode]["min"]) / 10
             summary[param][mode]["value"] = summary[param][mode]["mean"]
     return summary
+
+def create_slider(param_mode):
+    param, mode = param_mode.split("_")
+    return widgets.FloatSlider(**summary[param][mode])
+
+def create_sliders(slider_list):
+    return dict([(slider_name, create_slider(slider_name)) for slider_name in slider_list])
+
+def change_mean_from_kwargs(param_mode, kwargs):
+    param, mode = param_mode.split("_")
+    new_mean = kwargs[param_mode]
+    print("Changing mean for %s %s to %.4f by %.4f" % (param, mode, new_mean, new_mean - summary[param][mode]["mean"]))
+    # Don't forget to flatten here; otherwise the plot will fail because we can't calculate max of an array
+    return (params[param][mode] + (new_mean - summary[param][mode]["mean"])).flatten()
+
+# Read the parameters and generate baseline values
+params = generate_all()
+results = vphpl_pphpl_calc(params)
+summary = summarize_params()


### PR DESCRIPTION
…ual values

Concretely:
- compute summary statistics (mean, range, step) for the metrics
- use them to configure the sliders
- set the mean as the default value
- create a new function `change_mean` that is the equivalent of `stddev_gen`.
  It changes the mean by adding/subtracting from each value. The shift is
  passed in instead of being computed from the standard deviation
- create a new inline function `get_modified_peit` which is the equivalent of
  `calculate_peit_var` but with the new mean passed in. Leaving this inline for
  now as the equivalent of a formula in a paper. We can move it out if we think
  it is too much.
- Added some logs to the CDF printing to provide a numeric description of the
  values for those who prefer precision

TODO: See if we can remove the ugly copy-pasted code around creating the widgets through better use of the `interact` module